### PR TITLE
Add arm64 and armv7 support using buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u ${USERNAME} -p ${PASSWORD}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm
+          push: true
+          tags: |
+            ${USERNAME}/fluxcloud:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-FROM golang:1.16.1 as builder
+FROM golang:1.17 as builder
 WORKDIR /app
 COPY . .
-RUN GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./fluxcloud ./cmd/
 
-FROM alpine
+RUN if [ `uname -m` = "aarch64" ] ; then \
+        GO111MODULE=on GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o ./fluxcloud ./cmd/;  \
+    elif [ `uname -m` == "armv7l"] ; then \     
+        GO111MODULE=on GOOS=linux GOARM=7 GOARCH=arm CGO_ENABLED=0 go build -o ./fluxcloud ./cmd/; \
+    else \
+        GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./fluxcloud ./cmd/; \
+    fi
+
+FROM alpine:latest
 RUN apk update && apk add ca-certificates
 
 FROM gcr.io/distroless/static@sha256:48e0d165f07d499c02732d924e84efbc73df8021b12c24940e18a9306589430e


### PR DESCRIPTION
Hi

**Package Owner:** Subham Kumar

**PR change Details:**

Patch Details: Following files has been changed:
**.github/workflows/buildyml:** Added build.yml to build and push the docker image on docker hub using buildx.
**Dockerfile:** Updated Dockerfile to add support for arm64 and armv7.

PR Description: Here is my commit message :
Add arm64 and armv7 support using buildx.

**PR Description:**

The following file has been created and modified:

Added .github/workflows/build.yml to build and push the images for arm64 and armv7 on dockerhub using buildx.
Updated Dockerfile to add support for arm64 armv7.

Signed-off-by: odidev odidev@puresoftware.com

Reviewer: Pruthvi Teja Reddy
Thanks
Subham Kumar